### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/neodisk17/vscode-ext-flutter-color-viewer/security/code-scanning/1](https://github.com/neodisk17/vscode-ext-flutter-color-viewer/security/code-scanning/1)

To fix the problem, explicitly declare least-privilege `permissions:` for the workflow so that the automatically provided `GITHUB_TOKEN` does not inherit potentially broad repository or organization defaults. Since the shown jobs only check out code, install dependencies, run tests, run linting, and run gitleaks, they need at most read access to repository contents; they do not create or modify issues, PRs, or push commits.

The best way to fix this without changing existing functionality is to add a `permissions:` block at the workflow root, right after the `name: Tests` line (or after `on:` if preferred). Root-level permissions apply to all jobs unless overridden, so we can set `contents: read` globally. If in the future some job needs broader permissions, it can define its own `permissions:` block. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 1 and 3 of the current file. No imports or additional methods are required, since this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
