### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   release:
     types:
@@ -91,6 +93,8 @@ jobs:
   publishGH:
     name: Publish to GitHub releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: package
     if: github.event.inputs.publishGH == 'true'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/neodisk17/vscode-ext-flutter-color-viewer/security/code-scanning/2](https://github.com/neodisk17/vscode-ext-flutter-color-viewer/security/code-scanning/2)

In general, the fix is to explicitly set `permissions:` in the workflow so that the default `GITHUB_TOKEN` scope is minimized. Then, for any job that truly requires broader access, override `permissions:` at that job level with the specific write scopes needed.

For this workflow, the safest, non-breaking change is:
- Add a root-level `permissions:` block right after `name: Release` that sets `contents: read`. This applies to all jobs by default.
- Override permissions for the `publishGH` job, which creates and updates GitHub Releases using `actions/create-release` and `upload-release-assets`. That job needs to be able to write releases (and typically `contents: write` is sufficient and standard for those actions). So add a `permissions:` block under `publishGH:` with `contents: write`.

No other jobs appear to require write access: `package`, `publishMS`, and `publishOVSX` just check out code, build/package, and publish to external marketplaces using personal access tokens/secrets, so read-only `contents` is adequate.

Concretely:
- In `.github/workflows/main.yml`, add:

```yml
permissions:
  contents: read
```

below line 1.
- In the `publishGH` job definition, add:

```yml
    permissions:
      contents: write
```

under `runs-on: ubuntu-latest` (line 93), properly indented.

No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
